### PR TITLE
Allow unauthenticated visitors to access landing page

### DIFF
--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -38,11 +38,11 @@ export async function updateSession(request: NextRequest) {
   const { data } = await supabase.auth.getClaims()
   const user = data?.claims
 
-  if (
-    !user &&
-    !request.nextUrl.pathname.startsWith('/login') &&
-    !request.nextUrl.pathname.startsWith('/auth')
-  ) {
+  const pathname = request.nextUrl.pathname
+  const isAuthRoute = pathname.startsWith('/auth') || pathname.startsWith('/login')
+  const publicRoutes = new Set(['/'])
+
+  if (!user && !isAuthRoute && !publicRoutes.has(pathname)) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone()
     url.pathname = '/auth/login'


### PR DESCRIPTION
## Summary
- update the Supabase middleware so the public landing page no longer redirects to the login flow when unauthenticated

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d95aa282d48320b4ac92c200e28ab6