### PR TITLE
Add GitHub Action to run Supabase migrations on deployment

### DIFF
--- a/.github/workflows/run-supabase-migrations.yml
+++ b/.github/workflows/run-supabase-migrations.yml
@@ -1,0 +1,33 @@
+name: Run Supabase Migrations on Deploy
+
+on:
+  deployment_status:
+
+jobs:
+  run-migrations:
+    name: Apply Supabase migrations
+    if: github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    env:
+      # Prefer GitHub Secrets, but fall back to repository/environment variables when available.
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN || vars.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF || vars.SUPABASE_PROJECT_REF }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD || vars.SUPABASE_DB_PASSWORD }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Login to Supabase
+        run: supabase login --token "$SUPABASE_ACCESS_TOKEN"
+
+      - name: Link Supabase project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
+
+      - name: Run database migrations
+        run: supabase db push


### PR DESCRIPTION
## Summary
- add a deployment_status-triggered workflow that installs the Supabase CLI
- authenticate against the Supabase project and push pending migrations automatically
- allow Supabase credentials to be sourced from GitHub Secrets or repository/environment variables

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d95ec24f6c8320b94e4adb372c9719